### PR TITLE
CTDA-968: Set X-Correlation-Id and CustomProcessHost on messages to EIS

### DIFF
--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -16,6 +16,8 @@
 
 package connectors
 
+import java.util.UUID
+
 import com.google.inject.Inject
 import config.AppConfig
 import connectors.util.CustomHttpReader
@@ -39,7 +41,7 @@ class MessageConnector @Inject()(config: AppConfig, http: HttpClient)(implicit e
     Logger.debug("Header carrier extra headers are: " + headerCarrier.extraHeaders)
     Logger.debug("Header carrier other headers are: " + headerCarrier.otherHeaders)
 
-    val customHeaders = OutgoingRequestFilter()
+    val customHeaders = OutgoingRequestFilter() ++ extraHeaders
 
     Logger.debug("Custom headers are: " + customHeaders)
 
@@ -49,4 +51,10 @@ class MessageConnector @Inject()(config: AppConfig, http: HttpClient)(implicit e
 
     http.POSTString[HttpResponse](url, xml)(CustomHttpReader, newHeaderCarrier, implicitly)
   }
+
+  private def extraHeaders: Seq[(String, String)] =
+    Seq(
+      "X-Correlation-Id" -> UUID.randomUUID().toString,
+      "CustomProcessHost" -> "Digital"
+    )
 }

--- a/app/connectors/OutgoingRequestFilter.scala
+++ b/app/connectors/OutgoingRequestFilter.scala
@@ -20,8 +20,6 @@ import play.api.mvc.RequestHeader
 
 object OutgoingRequestFilter {
   val CustomUpstreamHeaders = Seq(
-    "x-forwarded-host",
-    "x-correlation-id",
     "date",
     "content-type",
     "accept",

--- a/it/connectors/WiremockSuite.scala
+++ b/it/connectors/WiremockSuite.scala
@@ -9,31 +9,28 @@ import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
 
 trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
   this: Suite =>
-  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+  protected val wiremockPort = 11111
+
+  protected val server: WireMockServer = new WireMockServer(wireMockConfig().port(wiremockPort))
 
   protected def portConfigKey: String
 
-  protected lazy val app: Application =
+  protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .configure(
         portConfigKey -> server.port().toString
       )
       .overrides(bindings: _*)
-      .build()
-
-  protected lazy val injector: Injector = app.injector
 
   protected def bindings: Seq[GuiceableModule] = Seq.empty
 
   override def beforeAll(): Unit = {
     server.start()
-    app
     super.beforeAll()
   }
 
   override def beforeEach(): Unit = {
     server.resetAll()
-    app
     super.beforeEach()
   }
 

--- a/test/connectors/OutgoingRequestFilterSpec.scala
+++ b/test/connectors/OutgoingRequestFilterSpec.scala
@@ -43,10 +43,8 @@ class OutgoingRequestFilterSpec extends AnyFreeSpec with Matchers with GuiceOneA
 
       val result: Seq[(String, String)] = OutgoingRequestFilter()
 
-      result.size mustBe 7
+      result.size mustBe 5
 
-      result must contain("X-Forwarded-Host" -> "mdtp")
-      result must contain("X-Correlation-ID" -> "137302f5-71ae-40a4-bd92-cac2ae7sde2f")
       result must contain("Date" -> "Tue, 29 Sep 2020 11:46:50 +0100")
       result must contain("Content-Type" -> "application/xml")
       result must contain("Accept" -> "application/xml")


### PR DESCRIPTION
This PR also updates the integration tests to use ScalaFutures rather than awaiting (so we get better output on failures), and to create a new app per test rather than relying on one for the whole suite.  Having a single app persist across multiple tests can cause issues in future, for example if one test needs different configuration than another or if we ever introduce mocking.