### PR TITLE
CTCTRADERS-443: Update dependencies and logging

### DIFF
--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -21,7 +21,6 @@ import java.util.UUID
 import com.google.inject.Inject
 import config.AppConfig
 import connectors.util.CustomHttpReader
-import play.api.Logger
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpResponse
@@ -33,17 +32,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class MessageConnector @Inject()(config: AppConfig, http: HttpClient)(implicit ec: ExecutionContext) {
 
   def post(xml: String)(implicit requestHeader: RequestHeader, headerCarrier: HeaderCarrier): Future[HttpResponse] = {
-    Logger.debug(s"About to send message:\n$xml")
     val url = config.eisUrl
 
-    Logger.debug("Request headers are: " + requestHeader.headers.headers)
-    Logger.debug("Header carrier headers are: " + headerCarrier.headers)
-    Logger.debug("Header carrier extra headers are: " + headerCarrier.extraHeaders)
-    Logger.debug("Header carrier other headers are: " + headerCarrier.otherHeaders)
-
     val customHeaders = OutgoingRequestFilter() ++ extraHeaders
-
-    Logger.debug("Custom headers are: " + customHeaders)
 
     val newHeaderCarrier = headerCarrier
       .copy(authorization = Some(Authorization(s"Bearer ${config.eisBearerToken}")))

--- a/app/connectors/util/CustomHttpReader.scala
+++ b/app/connectors/util/CustomHttpReader.scala
@@ -16,13 +16,14 @@
 
 package connectors.util
 
-import play.api.Logger
+import logging.Logging
 import play.api.http.Status
 import uk.gov.hmrc.http.{HttpErrorFunctions, HttpReads, HttpResponse}
 
-object CustomHttpReader extends HttpReads[HttpResponse] with HttpErrorFunctions with Status {
+object CustomHttpReader extends HttpReads[HttpResponse] with HttpErrorFunctions with Status with Logging {
+
   override def read(method: String, url: String, response: HttpResponse): HttpResponse = {
-    Logger.debug(s"CustomHttpReader Log\nstatus: ${response.status}\nbody: ${response.body}\nheaders: ${response.headers.map {
+    logger.debug(s"CustomHttpReader Log\nstatus: ${response.status}\nbody: ${response.body}\nheaders: ${response.headers.map {
       x =>
         s"\n  ${x._1} : ${x._2}"
     }}")

--- a/app/connectors/util/CustomHttpReader.scala
+++ b/app/connectors/util/CustomHttpReader.scala
@@ -23,15 +23,12 @@ import uk.gov.hmrc.http.{HttpErrorFunctions, HttpReads, HttpResponse}
 object CustomHttpReader extends HttpReads[HttpResponse] with HttpErrorFunctions with Status with Logging {
 
   override def read(method: String, url: String, response: HttpResponse): HttpResponse = {
-    logger.debug(s"CustomHttpReader Log\nstatus: ${response.status}\nbody: ${response.body}\nheaders: ${response.headers.map {
-      x =>
-        s"\n  ${x._1} : ${x._2}"
-    }}")
     response.status match {
       case UNAUTHORIZED => recode(INTERNAL_SERVER_ERROR, response)
       case INTERNAL_SERVER_ERROR | GATEWAY_TIMEOUT => recode(BAD_GATEWAY, response)
       case _ => response
     }
   }
+  
   def recode(newCode: Int, response: HttpResponse) = HttpResponse(newCode, response.body, response.headers)
 }

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package logging
 
 import play.api.Logger

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -1,0 +1,8 @@
+package logging
+
+import play.api.Logger
+
+trait Logging {
+
+  protected val logger: Logger = Logger(s"application.${this.getClass.getCanonicalName}")
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -100,7 +100,7 @@ metrics {
 # Microservice specific config
 
 auditing {
-  enabled = true
+  enabled = false
   traceRequests = true
   consumer {
     baseUri {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,11 +6,10 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-27"  % "2.24.0"
+    "uk.gov.hmrc"             %% "bootstrap-backend-play-27"  % "3.2.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-27"   % "2.24.0"                % Test,
     "org.scalatest"           %% "scalatest"                % "3.2.0"                 % Test,
     "com.typesafe.play"       %% "play-test"                % current                 % Test,
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.35.10"               % "test, it",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,11 +5,11 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.11.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 


### PR DESCRIPTION
This PR bumps libraries and plugins to the latest versions.  It also removes some debug-level logging that was writing message content to logs.

It also locally disables auditing, to reduce log spam in tests.  Auditing is enabled in all environments, this only affects local running.