### PR TITLE
CLI-152: Switch cumulative delay (which only acts on delays and not total invocation time) to be total timeout

### DIFF
--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -157,14 +157,18 @@ class MessageConnector @Inject() (
 
       lazy val logMessage = s"""|Posting NCTS message, ${details.routingMessage}
                                 |X-Correlation-Id: ${getHeader("X-Correlation-Id", details.url)}
-                                |${HMRCHeaderNames.xRequestId}: ${getHeader(HMRCHeaderNames.xRequestId, details.url)}
+                                |${HMRCHeaderNames.xRequestId}: ${getHeader(
+        HMRCHeaderNames.xRequestId,
+        details.url
+      )}
                                 |X-Message-Type: ${getHeader("X-Message-Type", details.url)}
                                 |X-Message-Sender: ${getHeader("X-Message-Sender", details.url)}
                                 |Accept: ${getHeader("Accept", details.url)}
                                 |CustomProcessHost: ${getHeader("CustomProcessHost", details.url)}
                                 |""".stripMargin
 
-      details.circuitBreaker.withCircuitBreaker(
+      details.circuitBreaker
+        .withCircuitBreaker(
           {
             http
               .POSTString[HttpResponse](details.url, xml.toString)
@@ -180,7 +184,7 @@ class MessageConnector @Inject() (
               }
               .recover { case NonFatal(e) =>
                 val message = logMessage +
-                    s"Request Error: ${details.url} failed to retrieve data with message ${e.getMessage}"
+                  s"Request Error: ${details.url} failed to retrieve data with message ${e.getMessage}"
                 logger.error(message)
                 HttpResponse(Status.INTERNAL_SERVER_ERROR, message)
               }

--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -155,12 +155,10 @@ class MessageConnector @Inject() (
         .copy(authorization = None, otherHeaders = Seq.empty)
         .withExtraHeaders(requestHeaders: _*)
 
+      val requestId       = getHeader(HMRCHeaderNames.xRequestId, details.url)
       lazy val logMessage = s"""|Posting NCTS message, ${details.routingMessage}
                                 |X-Correlation-Id: ${getHeader("X-Correlation-Id", details.url)}
-                                |${HMRCHeaderNames.xRequestId}: ${getHeader(
-        HMRCHeaderNames.xRequestId,
-        details.url
-      )}
+                                |${HMRCHeaderNames.xRequestId}: $requestId
                                 |X-Message-Type: ${getHeader("X-Message-Type", details.url)}
                                 |X-Message-Sender: ${getHeader("X-Message-Sender", details.url)}
                                 |Accept: ${getHeader("Accept", details.url)}


### PR DESCRIPTION
This will mean that the retry code will now take into account the time taken to invoke the enclosing function, rather than just the sum of the time that the retry library itself has delayed the code.

This brings it in line with the intention we had. Additional tests have been added to verify required behaviour.