### PR TITLE
CLI-199: Vary request timeouts based upon whether a message is small or large

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -28,28 +28,40 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val authBaseUrl: String = servicesConfig.baseUrl("auth")
 
   val auditingEnabled: Boolean = config.get[Boolean]("auditing.enabled")
+
   val nctsMonitoringEnabled: Boolean =
     config.get[Boolean]("microservice.features.routing.ncts-monitoring")
   val graphiteHost: String = config.get[String]("microservice.metrics.graphite.host")
 
   private val eisBaseUrl: String = servicesConfig.baseUrl("eis")
   val eisniUrl: String           = eisBaseUrl ++ config.get[String]("microservice.services.eis.ni.uri")
+
   val eisniBearerToken: String =
     config.get[String]("microservice.services.eis.ni.headers.bearerToken")
   val eisgbUrl: String = eisBaseUrl ++ config.get[String]("microservice.services.eis.gb.uri")
+
   val eisgbBearerToken: String =
     config.get[String]("microservice.services.eis.gb.headers.bearerToken")
   val nctsMonitoringBaseUrl: String = servicesConfig.baseUrl("ncts-monitoring")
+
   val nctsMonitoringUrl: String =
     nctsMonitoringBaseUrl ++ config.get[String]("microservice.services.ncts-monitoring.uri")
 
   val eisgbCircuitBreaker: CircuitBreakerConfig =
     CircuitBreakerConfig.fromServicesConfig("eis.gb", config)
+
   val eisniCircuitBreaker: CircuitBreakerConfig =
     CircuitBreakerConfig.fromServicesConfig("eis.ni", config)
 
   val eisgbRetry: RetryConfig =
     RetryConfig.fromServicesConfig("eis.gb", config)
+
   val eisniRetry: RetryConfig =
     RetryConfig.fromServicesConfig("eis.ni", config)
+
+  val eisgbTimeout: RequestTimeoutConfig =
+    RequestTimeoutConfig.fromServicesConfig("eis.gb", config)
+
+  val eisniTimeout: RequestTimeoutConfig =
+    RequestTimeoutConfig.fromServicesConfig("eis.ni", config)
 }

--- a/app/config/RequestTimeoutConfig.scala
+++ b/app/config/RequestTimeoutConfig.scala
@@ -18,11 +18,9 @@ package config
 
 import play.api.Configuration
 
-import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.FiniteDuration
 
 case class RequestTimeoutConfig(messageSizeLimit: Int, smallMessageTimeout: FiniteDuration, largeMessageTimeout: FiniteDuration) {
-  def timeout(message: String): FiniteDuration = timeout(message.getBytes(StandardCharsets.UTF_8).length)
 
   def timeout(messageSize: Int): FiniteDuration =
     if (messageSize <= messageSizeLimit) smallMessageTimeout

--- a/app/config/RequestTimeoutConfig.scala
+++ b/app/config/RequestTimeoutConfig.scala
@@ -18,38 +18,29 @@ package config
 
 import play.api.Configuration
 
+import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.FiniteDuration
 
-case class CircuitBreakerConfig(
-  maxFailures: Int,
-  callTimeout: FiniteDuration,
-  resetTimeout: FiniteDuration,
-  maxResetTimeout: FiniteDuration,
-  exponentialBackoffFactor: Double,
-  randomFactor: Double
-)
+case class RequestTimeoutConfig(messageSizeLimit: Int, smallMessageTimeout: FiniteDuration, largeMessageTimeout: FiniteDuration) {
+  def timeout(message: String): FiniteDuration = timeout(message.getBytes(StandardCharsets.UTF_8).length)
 
-object CircuitBreakerConfig {
+  def timeout(messageSize: Int): FiniteDuration =
+    if (messageSize <= messageSizeLimit) smallMessageTimeout
+    else largeMessageTimeout
+}
+
+object RequestTimeoutConfig {
 
   def fromServicesConfig(serviceName: String, config: Configuration) =
-    CircuitBreakerConfig(
+    RequestTimeoutConfig(
       config.get[Int](
-        s"microservice.services.$serviceName.circuit-breaker.max-failures"
+        s"microservice.services.$serviceName.request-timeout.small-message-size-limit"
       ),
       config.get[FiniteDuration](
-        s"microservice.services.$serviceName.circuit-breaker.call-timeout"
+        s"microservice.services.$serviceName.request-timeout.small-message-timeout"
       ),
       config.get[FiniteDuration](
-        s"microservice.services.$serviceName.circuit-breaker.reset-timeout"
-      ),
-      config.get[FiniteDuration](
-        s"microservice.services.$serviceName.circuit-breaker.max-reset-timeout"
-      ),
-      config.get[Double](
-        s"microservice.services.$serviceName.circuit-breaker.exponential-backoff-factor"
-      ),
-      config.get[Double](
-        s"microservice.services.$serviceName.circuit-breaker.random-factor"
+        s"microservice.services.$serviceName.request-timeout.large-message-timeout"
       )
     )
 }

--- a/app/config/RetryConfig.scala
+++ b/app/config/RetryConfig.scala
@@ -23,6 +23,7 @@ import scala.concurrent.duration.FiniteDuration
 case class RetryConfig(maxRetries: Int, delay: FiniteDuration, timeout: FiniteDuration)
 
 object RetryConfig {
+
   def fromServicesConfig(serviceName: String, config: Configuration) =
     RetryConfig(
       config.get[Int](

--- a/app/connectors/CircuitBreakers.scala
+++ b/app/connectors/CircuitBreakers.scala
@@ -39,24 +39,27 @@ trait CircuitBreakers { self: Logging =>
     exponentialBackoffFactor = gbCircuitBreakerConfig.exponentialBackoffFactor,
     randomFactor = gbCircuitBreakerConfig.randomFactor
   )(materializer.executionContext)
-    .onOpen(logger.error(s"GB Circuit breaker for ${clazz} opening due to failures"))
-    .onHalfOpen(logger.warn(s"GB Circuit breaker for ${clazz} resetting after failures"))
+    .onOpen(logger.error(s"GB Circuit breaker for $clazz opening due to failures"))
+    .onHalfOpen(logger.warn(s"GB Circuit breaker for $clazz resetting after failures"))
     .onClose {
       logger.warn(
-        s"GB Circuit breaker for ${clazz} closing after trial connection success"
+        s"GB Circuit breaker for $clazz closing after trial connection success"
       )
     }
-    .onCallFailure(_ => logger.error(s"GB Circuit breaker for ${clazz} recorded failed call"))
+    .onCallFailure(
+      _ => logger.error(s"GB Circuit breaker for $clazz recorded failed call")
+    )
     .onCallBreakerOpen {
       logger.error(
-        s"GB Circuit breaker for ${clazz} rejected call due to previous failures"
+        s"GB Circuit breaker for $clazz rejected call due to previous failures"
       )
     }
-    .onCallTimeout { elapsed =>
-      val duration = Duration.fromNanos(elapsed)
-      logger.error(
-        s"GB Circuit breaker for ${clazz} recorded failed call due to timeout after ${duration.toMillis}ms"
-      )
+    .onCallTimeout {
+      elapsed =>
+        val duration = Duration.fromNanos(elapsed)
+        logger.error(
+          s"GB Circuit breaker for $clazz recorded failed call due to timeout after ${duration.toMillis}ms"
+        )
     }
 
   lazy val niCircuitBreaker = new CircuitBreaker(
@@ -68,24 +71,27 @@ trait CircuitBreakers { self: Logging =>
     exponentialBackoffFactor = niCircuitBreakerConfig.exponentialBackoffFactor,
     randomFactor = niCircuitBreakerConfig.randomFactor
   )(materializer.executionContext)
-    .onOpen(logger.error(s"NI Circuit breaker for ${clazz} opening due to failures"))
-    .onHalfOpen(logger.warn(s"NI Circuit breaker for ${clazz} resetting after failures"))
+    .onOpen(logger.error(s"NI Circuit breaker for $clazz opening due to failures"))
+    .onHalfOpen(logger.warn(s"NI Circuit breaker for $clazz resetting after failures"))
     .onClose {
       logger.warn(
-        s"NI Circuit breaker for ${clazz} closing after trial connection success"
+        s"NI Circuit breaker for $clazz closing after trial connection success"
       )
     }
-    .onCallFailure(_ => logger.error(s"NI Circuit breaker for ${clazz} recorded failed call"))
+    .onCallFailure(
+      _ => logger.error(s"NI Circuit breaker for $clazz recorded failed call")
+    )
     .onCallBreakerOpen {
       logger.error(
-        s"NI Circuit breaker for ${clazz} rejected call due to previous failures"
+        s"NI Circuit breaker for $clazz rejected call due to previous failures"
       )
     }
-    .onCallTimeout { elapsed =>
-      val duration = Duration.fromNanos(elapsed)
-      logger.error(
-        s"NI Circuit breaker for ${clazz} recorded failed call due to timeout after ${duration.toMillis}ms"
-      )
+    .onCallTimeout {
+      elapsed =>
+        val duration = Duration.fromNanos(elapsed)
+        logger.error(
+          s"NI Circuit breaker for $clazz recorded failed call due to timeout after ${duration.toMillis}ms"
+        )
     }
 
 }

--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -21,6 +21,7 @@ import akka.stream.Materializer
 import com.google.inject.Inject
 import config.AppConfig
 import config.CircuitBreakerConfig
+import config.RequestTimeoutConfig
 import config.RetryConfig
 import models.Movement
 import models.RoutingOption
@@ -42,9 +43,14 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.StringContextOps
+import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderNames => HMRCHeaderNames}
 
 import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -57,6 +63,7 @@ class MessageConnector @Inject() (
   appConfig: AppConfig,
   config: Configuration,
   http: HttpClient,
+  httpv2: HttpClientV2,
   retries: RetriesService
 )(implicit
   ec: ExecutionContext,
@@ -69,23 +76,28 @@ class MessageConnector @Inject() (
     token: String,
     routingMessage: String,
     circuitBreaker: CircuitBreaker,
-    retryConfig: RetryConfig
+    retryConfig: RetryConfig,
+    requestTimeoutConfig: RequestTimeoutConfig
   )
+
   private lazy val niEisDetails =
     EisDetails(
       appConfig.eisniUrl,
       appConfig.eisniBearerToken,
       "routing to NI",
       niCircuitBreaker,
-      appConfig.eisniRetry
+      appConfig.eisniRetry,
+      appConfig.eisniTimeout
     )
+
   private lazy val gbEisDetails =
     EisDetails(
       appConfig.eisgbUrl,
       appConfig.eisgbBearerToken,
       "routing to GB",
       gbCircuitBreaker,
-      appConfig.eisgbRetry
+      appConfig.eisgbRetry,
+      appConfig.eisgbTimeout
     )
 
   private val headerCarrierConfig = HeaderCarrier.Config.fromConfig(config.underlying)
@@ -93,8 +105,12 @@ class MessageConnector @Inject() (
   def getHeader(header: String, url: String)(implicit hc: HeaderCarrier): String =
     hc
       .headersForUrl(headerCarrierConfig)(url)
-      .find { case (name, _) => name.toLowerCase == header.toLowerCase }
-      .map { case (_, value) => value }
+      .find {
+        case (name, _) => name.toLowerCase == header.toLowerCase
+      }
+      .map {
+        case (_, value) => value
+      }
       .getOrElse("undefined")
 
   override lazy val gbCircuitBreakerConfig: CircuitBreakerConfig = appConfig.eisgbCircuitBreaker
@@ -123,7 +139,11 @@ class MessageConnector @Inject() (
       )
     } else {
       val nextAttempt =
-        retryDetails.upcomingDelay.map(d => s"in ${d.toSeconds} seconds").getOrElse("immediately")
+        retryDetails.upcomingDelay
+          .map(
+            d => s"in ${d.toSeconds} seconds"
+          )
+          .getOrElse("immediately")
       logger.warn(
         s"Message when $instance failed with status code ${httpResponse.status}. " +
           s"Attempted $attemptNumber times in ${retryDetails.cumulativeDelay.toSeconds} seconds so far, trying again $nextAttempt."
@@ -137,6 +157,9 @@ class MessageConnector @Inject() (
       case Xi => niEisDetails
       case Gb => gbEisDetails
     }
+
+    val payload = xml.mkString
+    val timeout = details.requestTimeoutConfig.timeout(payload)
 
     // It is assumed that all errors are fatal (see recover block) and so we just need to retry on failures.
     retryingOnFailures(
@@ -163,14 +186,20 @@ class MessageConnector @Inject() (
                                 |X-Message-Sender: ${getHeader("X-Message-Sender", details.url)}
                                 |Accept: ${getHeader("Accept", details.url)}
                                 |CustomProcessHost: ${getHeader("CustomProcessHost", details.url)}
+                                |Timestamp (UTC): ${DateTimeFormatter.ISO_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC))}
                                 |""".stripMargin
 
       details.circuitBreaker
         .withCircuitBreaker(
-          {
-            http
-              .POSTString[HttpResponse](details.url, xml.toString)
-              .map { result =>
+          httpv2
+            .post(url"${details.url}")
+            .withBody(payload)
+            .transform(
+              req => req.withRequestTimeout(timeout)
+            )
+            .execute[HttpResponse]
+            .map {
+              result =>
                 val logMessageWithStatus = logMessage + s"Response status: ${result.status}"
 
                 if (statusCodeFailure(result))
@@ -179,20 +208,21 @@ class MessageConnector @Inject() (
                   logger.info(logMessageWithStatus)
 
                 result
-              }
-              .recover { case NonFatal(e) =>
+            }
+            .recover {
+              case NonFatal(e) =>
                 val message = logMessage +
                   s"Request Error: ${details.url} failed to retrieve data with message ${e.getMessage}"
                 logger.error(message)
                 HttpResponse(Status.INTERNAL_SERVER_ERROR, message)
-              }
-          },
+            },
           shouldCauseCircuitBreakerStrike
         )
-        .recover { case NonFatal(e) =>
-          val message = logMessage + s"Error: Unable to process message ${e.getMessage}"
-          logger.error(message)
-          HttpResponse(Status.INTERNAL_SERVER_ERROR, message)
+        .recover {
+          case NonFatal(e) =>
+            val message = logMessage + s"Error: Unable to process message ${e.getMessage}"
+            logger.error(message)
+            HttpResponse(Status.INTERNAL_SERVER_ERROR, message)
         }
     }
   }
@@ -219,16 +249,18 @@ class MessageConnector @Inject() (
 
     http
       .POSTString[HttpResponse](appConfig.nctsMonitoringUrl, movementJson.toString())
-      .map { result =>
-        if (result.status != Status.OK)
-          logger.warn(s"[MessageConnector][postNCTSMonitoring] Failed with status ${result.status}")
-        result.status
+      .map {
+        result =>
+          if (result.status != Status.OK)
+            logger.warn(s"[MessageConnector][postNCTSMonitoring] Failed with status ${result.status}")
+          result.status
       }
-      .recover { case NonFatal(e) =>
-        val message =
-          s"[MessageConnector][postNCTSMonitoring] ${appConfig.nctsMonitoringUrl} failed to send movement to ncts monitoring with message ${e.getMessage}"
-        logger.warn(message)
-        INTERNAL_SERVER_ERROR
+      .recover {
+        case NonFatal(e) =>
+          val message =
+            s"[MessageConnector][postNCTSMonitoring] ${appConfig.nctsMonitoringUrl} failed to send movement to ncts monitoring with message ${e.getMessage}"
+          logger.warn(message)
+          INTERNAL_SERVER_ERROR
       }
   }
 }

--- a/app/connectors/OutgoingHeaders.scala
+++ b/app/connectors/OutgoingHeaders.scala
@@ -20,6 +20,7 @@ import play.api.http.HeaderNames
 import uk.gov.hmrc.http.{HeaderNames => HMRCHeaderNames}
 
 object OutgoingHeaders {
+
   val headers = Seq(
     HeaderNames.DATE,
     HeaderNames.CONTENT_TYPE,

--- a/app/controllers/actions/ChannelAction.scala
+++ b/app/controllers/actions/ChannelAction.scala
@@ -29,8 +29,7 @@ import play.api.mvc.Results.BadRequest
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class ChannelAction @Inject() ()(implicit val executionContext: ExecutionContext)
-    extends ActionRefiner[Request, ChannelRequest] {
+class ChannelAction @Inject() ()(implicit val executionContext: ExecutionContext) extends ActionRefiner[Request, ChannelRequest] {
 
   override protected def refine[A](
     request: Request[A]

--- a/app/models/GuaranteeReference.scala
+++ b/app/models/GuaranteeReference.scala
@@ -20,6 +20,7 @@ import models.RoutingOption.Gb
 import models.RoutingOption.Xi
 
 case class GuaranteeReference(value: String) extends AnyVal {
+
   def countryCode: String =
     value.drop(2).take(2)
 

--- a/app/models/MessageTypes.scala
+++ b/app/models/MessageTypes.scala
@@ -16,9 +16,7 @@
 
 package models
 
-sealed abstract class MessageType(val code: String, val rootNode: String)
-    extends Product
-    with Serializable
+sealed abstract class MessageType(val code: String, val rootNode: String) extends Product with Serializable
 
 object MessageType {
   case object ArrivalNotification            extends MessageType("IE007", "CC007A")

--- a/app/models/Movement.scala
+++ b/app/models/Movement.scala
@@ -16,7 +16,8 @@
 
 package models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
 
 import java.time.LocalDateTime
 

--- a/app/models/Offices.scala
+++ b/app/models/Offices.scala
@@ -16,10 +16,12 @@
 
 package models
 
-import models.RoutingOption.{Gb, Xi}
+import models.RoutingOption.Gb
+import models.RoutingOption.Xi
 
 sealed abstract class Office extends Product with Serializable {
   def value: String
+
   def getRoutingOption: RoutingOption =
     if (value.startsWith(Xi.prefix)) Xi else Gb
 }

--- a/app/models/requests/ChannelRequest.scala
+++ b/app/models/requests/ChannelRequest.scala
@@ -17,7 +17,7 @@
 package models.requests
 
 import models.ChannelType
-import play.api.mvc.{Request, WrappedRequest}
+import play.api.mvc.Request
+import play.api.mvc.WrappedRequest
 
-case class ChannelRequest[A](request: Request[A], channel: ChannelType)
-    extends WrappedRequest[A](request)
+case class ChannelRequest[A](request: Request[A], channel: ChannelType) extends WrappedRequest[A](request)

--- a/app/services/RetriesService.scala
+++ b/app/services/RetriesService.scala
@@ -42,13 +42,12 @@ class RetriesServiceImpl extends RetriesService {
 
   override def createRetryPolicy(
     config: RetryConfig
-  )(implicit ec: ExecutionContext): RetryPolicy[Future] = {
+  )(implicit ec: ExecutionContext): RetryPolicy[Future] =
     limitRetriesByTotalTime(
       config.timeout,
       RetryPolicies.limitRetries[Future](config.maxRetries) join RetryPolicies
         .constantDelay[Future](config.delay)
     )
-  }
 
   def limitRetriesByTotalTime[M[_]: Applicative](
     threshold: FiniteDuration,

--- a/app/services/RouteChecker.scala
+++ b/app/services/RouteChecker.scala
@@ -17,18 +17,20 @@
 package services
 
 import com.google.inject.Inject
-import models.ChannelType.{Api, Web}
-import models.RoutingOption.{Gb, Xi}
-import models.{ChannelType, RoutingOption}
+import models.ChannelType.Api
+import models.ChannelType.Web
+import models.RoutingOption.Gb
+import models.RoutingOption.Xi
+import models.ChannelType
+import models.RoutingOption
 
 class RouteChecker @Inject() (routingConfig: RoutingConfig) {
 
-  def canForward(routingOption: RoutingOption, channelType: ChannelType): Boolean = {
+  def canForward(routingOption: RoutingOption, channelType: ChannelType): Boolean =
     (channelType, routingOption) match {
       case (Api, Xi) => routingConfig.apiXi
       case (Web, Xi) => routingConfig.webXi
       case (Api, Gb) => routingConfig.apiGb
       case (Web, Gb) => routingConfig.webGb
     }
-  }
 }

--- a/app/services/RoutingConfig.scala
+++ b/app/services/RoutingConfig.scala
@@ -16,7 +16,8 @@
 
 package services
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.Inject
+import com.google.inject.Singleton
 import play.api.Configuration
 
 @Singleton

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,6 +38,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
@@ -115,6 +116,11 @@ microservice {
       ni {
         uri = "/transits-movements-trader-at-departure-stub/movements/departures/ni"
         headers.bearerToken = "bearertokenhereNI"
+        request-timeout {
+          small-message-timeout = 5 seconds
+          large-message-timeout = 29 seconds
+          small-message-size-limit = 500000 # in bytes
+        }
         circuit-breaker {
           max-failures = 5
           call-timeout = 30 seconds
@@ -132,6 +138,11 @@ microservice {
       gb {
         uri = "/transits-movements-trader-at-departure-stub/movements/departures/gb"
         headers.bearerToken = "bearertokenhereGB"
+        request-timeout {
+          small-message-timeout = 5 seconds
+          large-message-timeout = 29 seconds
+          small-message-size-limit = 500000 # in bytes
+        }
         circuit-breaker {
           max-failures = 5
           call-timeout = 30 seconds

--- a/it/connectors/MessageConnectorSpec.scala
+++ b/it/connectors/MessageConnectorSpec.scala
@@ -21,7 +21,8 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import config.AppConfig
 import config.RetryConfig
-import models.{Movement, RoutingOption}
+import models.Movement
+import models.RoutingOption
 import models.RoutingOption.Gb
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -47,6 +48,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.http.HttpReads
 import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.client.RequestBuilder
 
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -94,8 +97,8 @@ class MessageConnectorSpec
 
     "add CustomProcessHost and X-Correlation-Id headers to messages for GB" in forAll(
       appBuilderGen
-    ) { appBuilder =>
-      {
+    ) {
+      appBuilder =>
         server.resetAll()
         val app = appBuilder.build()
 
@@ -142,13 +145,12 @@ class MessageConnectorSpec
 
           result.status mustEqual ACCEPTED
         }
-      }
     }
 
     "add CustomProcessHost and X-Correlation-Id headers to messages for XI" in forAll(
       appBuilderGen
-    ) { appBuilder =>
-      {
+    ) {
+      appBuilder =>
         server.resetAll()
         val app = appBuilder.build()
 
@@ -185,11 +187,10 @@ class MessageConnectorSpec
 
           result.status mustEqual ACCEPTED
         }
-      }
     }
 
-    "return ACCEPTED when post is successful" in forAll(appBuilderGen) { appBuilder =>
-      {
+    "return ACCEPTED when post is successful" in forAll(appBuilderGen) {
+      appBuilder =>
         server.resetAll()
         val app = appBuilder.build()
 
@@ -225,7 +226,6 @@ class MessageConnectorSpec
 
           result.status mustEqual ACCEPTED
         }
-      }
     }
 
     "return ACCEPTED when post is successful on retry if there is an initial failure" in {
@@ -276,73 +276,68 @@ class MessageConnectorSpec
 
     "pass through error status codes" in forAll(errorCodes, appBuilderGen) {
       (statusCode, appBuilder) =>
-        {
-          val app = appBuilder.build()
+        val app = appBuilder.build()
 
-          running(app) {
-            val connector = app.injector.instanceOf[MessageConnector]
+        running(app) {
+          val connector = app.injector.instanceOf[MessageConnector]
 
-            server.stubFor(
-              post(
-                urlEqualTo("/transits-movements-trader-at-departure-stub/movements/departures/gb")
-              ).withHeader("Authorization", equalTo("Bearer bearertokenhereGB"))
-                .withHeader(HeaderNames.ACCEPT, equalTo("application/xml"))
-                .withHeader(
-                  "X-Correlation-Id",
-                  matching(
-                    "\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b"
-                  )
+          server.stubFor(
+            post(
+              urlEqualTo("/transits-movements-trader-at-departure-stub/movements/departures/gb")
+            ).withHeader("Authorization", equalTo("Bearer bearertokenhereGB"))
+              .withHeader(HeaderNames.ACCEPT, equalTo("application/xml"))
+              .withHeader(
+                "X-Correlation-Id",
+                matching(
+                  "\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b"
                 )
-                .willReturn(aResponse().withStatus(statusCode))
-            )
+              )
+              .willReturn(aResponse().withStatus(statusCode))
+          )
 
-            val hc = HeaderCarrier()
+          val hc = HeaderCarrier()
 
-            val result = connector.post(<document></document>, Gb, hc).futureValue
+          val result = connector.post(<document></document>, Gb, hc).futureValue
 
-            result.status mustEqual statusCode
-          }
+          result.status mustEqual statusCode
         }
     }
 
     "handle exceptions by returning an HttpResponse with status code 500" in forAll(appBuilderGen) {
       appBuilder =>
-        {
-          val app = appBuilder.build()
+        val app = appBuilder.build()
 
-          running(app) {
-            implicit val materializer = app.injector.instanceOf[Materializer]
-            val appConfig             = app.injector.instanceOf[AppConfig]
-            val config                = app.injector.instanceOf[Configuration]
-            val retriesService        = app.injector.instanceOf[RetriesService]
-            val http                  = mock[HttpClient]
+        running(app) {
+          implicit val materializer = app.injector.instanceOf[Materializer]
+          val appConfig             = app.injector.instanceOf[AppConfig]
+          val config                = app.injector.instanceOf[Configuration]
+          val retriesService        = app.injector.instanceOf[RetriesService]
+          val http                  = mock[HttpClient]
+          val httpv2                = mock[HttpClientV2]
 
-            when(
-              http.POSTString(
-                any(): String,
-                any(): String,
-                any(): Seq[(String, String)]
-              )(
-                any(): HttpReads[HttpResponse],
-                any(): HeaderCarrier,
-                any(): ExecutionContext
-              )
-            ).thenReturn(failed(new RuntimeException("Simulated timeout")))
+          val requestBuilder = mock[RequestBuilder]
 
-            val connector = new MessageConnector(appConfig, config, http, retriesService)
-            val hc        = HeaderCarrier()
-            val result    = connector.post(<document></document>, Gb, hc)
+          when(
+            httpv2.post(any())(any())
+          ).thenReturn(requestBuilder)
 
-            result.futureValue.status mustEqual INTERNAL_SERVER_ERROR
-          }
+          when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+          when(requestBuilder.transform(any())).thenReturn(requestBuilder)
+          when(requestBuilder.execute(any(), any())).thenReturn(failed(new RuntimeException("Simulated timeout")))
+
+          val connector = new MessageConnector(appConfig, config, http, httpv2, retriesService)
+          val hc        = HeaderCarrier()
+          val result    = connector.post(<document></document>, Gb, hc)
+
+          result.futureValue.status mustEqual INTERNAL_SERVER_ERROR
         }
     }
   }
 
   "postNCTSMonitoring" should {
 
-    "return 200 when post is successful" in forAll(appBuilderGen) { appBuilder =>
-      {
+    "return 200 when post is successful" in forAll(appBuilderGen) {
+      appBuilder =>
         val app = appBuilder.build()
 
         running(app) {
@@ -375,7 +370,6 @@ class MessageConnectorSpec
 
           result mustEqual OK
         }
-      }
     }
 
     val errorCodes = Gen.oneOf(
@@ -416,40 +410,39 @@ class MessageConnectorSpec
 
     "handle exceptions by returning an HttpResponse with status code 500" in forAll(appBuilderGen) {
       appBuilder =>
-        {
-          val app = appBuilder.build()
+        val app = appBuilder.build()
 
-          running(app) {
-            implicit val materializer = app.injector.instanceOf[Materializer]
-            val appConfig             = app.injector.instanceOf[AppConfig]
-            val config                = app.injector.instanceOf[Configuration]
-            val retriesService        = app.injector.instanceOf[RetriesService]
-            val http                  = mock[HttpClient]
+        running(app) {
+          implicit val materializer = app.injector.instanceOf[Materializer]
+          val appConfig             = app.injector.instanceOf[AppConfig]
+          val config                = app.injector.instanceOf[Configuration]
+          val retriesService        = app.injector.instanceOf[RetriesService]
+          val http                  = mock[HttpClient]
+          val httpv2                = mock[HttpClientV2]
 
-            when(
-              http.POSTString(
-                any(): String,
-                any(): String,
-                any(): Seq[(String, String)]
-              )(
-                any(): HttpReads[HttpResponse],
-                any(): HeaderCarrier,
-                any(): ExecutionContext
-              )
-            ).thenReturn(failed(new RuntimeException("Simulated timeout")))
+          when(
+            http.POSTString(
+              any(): String,
+              any(): String,
+              any(): Seq[(String, String)]
+            )(
+              any(): HttpReads[HttpResponse],
+              any(): HeaderCarrier,
+              any(): ExecutionContext
+            )
+          ).thenReturn(failed(new RuntimeException("Simulated timeout")))
 
-            val connector = new MessageConnector(appConfig, config, http, retriesService)
-            val result = connector
-              .postNCTSMonitoring(
-                "TEST-ID",
-                LocalDateTime.ofEpochSecond(1638349126L, 0, ZoneOffset.UTC),
-                Gb,
-                HeaderCarrier()
-              )
-              .futureValue
+          val connector = new MessageConnector(appConfig, config, http, httpv2, retriesService)
+          val result = connector
+            .postNCTSMonitoring(
+              "TEST-ID",
+              LocalDateTime.ofEpochSecond(1638349126L, 0, ZoneOffset.UTC),
+              Gb,
+              HeaderCarrier()
+            )
+            .futureValue
 
-            result mustEqual INTERNAL_SERVER_ERROR
-          }
+          result mustEqual INTERNAL_SERVER_ERROR
         }
     }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,11 +5,11 @@ import sbt._
 
 object AppDependencies {
 
-  private val catsVersion      = "2.6.1"
+  private val catsVersion      = "2.8.0"
   private val catsRetryVersion = "3.1.0"
 
   val compile = Seq(
-    "uk.gov.hmrc"      %% "bootstrap-backend-play-28" % "5.24.0",
+    "uk.gov.hmrc"      %% "bootstrap-backend-play-28" % "7.8.0",
     "org.typelevel"    %% "cats-core"                 % catsVersion,
     "com.github.cb372" %% "cats-retry"                % catsRetryVersion,
     "com.github.cb372" %% "alleycats-retry"           % catsRetryVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/test/config/RequestTimeoutConfigSpec.scala
+++ b/test/config/RequestTimeoutConfigSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.concurrent.duration.DurationInt
+
+class RequestTimeoutConfigSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "RequestTimeoutConfig" - {
+    val sut = RequestTimeoutConfig(100, 1.second, 2.seconds)
+
+    "ensure that a small message timeout is selected for a small message" in forAll(Gen.oneOf(Range(1, 101))) {
+      sut.timeout(_) mustBe 1.second
+    }
+
+    "ensure that a large message timeout is selected for a large message" in forAll(Gen.oneOf(Range(101, 1000))) {
+      sut.timeout(_) mustBe 2.seconds
+    }
+  }
+
+}

--- a/test/controllers/MessagesControllerSpec.scala
+++ b/test/controllers/MessagesControllerSpec.scala
@@ -27,21 +27,20 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.http.{HeaderNames, MimeTypes}
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
 import play.api.libs.json.Json
 import play.api.mvc.AnyContentAsXml
 import play.api.test.Helpers._
-import play.api.test.{FakeHeaders, FakeRequest, Helpers}
+import play.api.test.FakeHeaders
+import play.api.test.FakeRequest
+import play.api.test.Helpers
 import services.RoutingService
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 
-class MessagesControllerSpec
-    extends AnyWordSpec
-    with Matchers
-    with GuiceOneAppPerSuite
-    with MockitoSugar {
+class MessagesControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with MockitoSugar {
 
   val requestXmlBody = <CC007A>
     <SynIdeMES1>UNOC</SynIdeMES1>

--- a/test/controllers/actions/ChannelActionSpec.scala
+++ b/test/controllers/actions/ChannelActionSpec.scala
@@ -39,6 +39,7 @@ import scala.xml.NodeSeq
 class ChannelActionSpec extends AnyFreeSpec with Matchers with ScalaFutures with EitherValues {
 
   private class Harness extends ChannelAction {
+
     def call[A](request: Request[A]): Future[Either[Result, ChannelRequest[A]]] =
       refine(request)
   }
@@ -48,8 +49,9 @@ class ChannelActionSpec extends AnyFreeSpec with Matchers with ScalaFutures with
       val futureResult =
         new Harness().call(FakeRequest("POST", routes.MessagesController.post.url))
 
-      whenReady(futureResult) { result =>
-        status(Future.successful(result.left.get)) mustBe BAD_REQUEST
+      whenReady(futureResult) {
+        result =>
+          status(Future.successful(result.left.get)) mustBe BAD_REQUEST
       }
     }
 
@@ -63,8 +65,9 @@ class ChannelActionSpec extends AnyFreeSpec with Matchers with ScalaFutures with
         )
       )
 
-      whenReady(futureResult) { result =>
-        status(Future.successful(result.left.get)) mustBe BAD_REQUEST
+      whenReady(futureResult) {
+        result =>
+          status(Future.successful(result.left.get)) mustBe BAD_REQUEST
       }
     }
 
@@ -78,8 +81,9 @@ class ChannelActionSpec extends AnyFreeSpec with Matchers with ScalaFutures with
         )
       )
 
-      whenReady(futureResult) { result =>
-        result.right.get.channel mustBe Web
+      whenReady(futureResult) {
+        result =>
+          result.right.get.channel mustBe Web
       }
     }
 
@@ -93,8 +97,9 @@ class ChannelActionSpec extends AnyFreeSpec with Matchers with ScalaFutures with
         )
       )
 
-      whenReady(futureResult) { result =>
-        result.right.get.channel mustBe Api
+      whenReady(futureResult) {
+        result =>
+          result.right.get.channel mustBe Api
       }
     }
   }

--- a/test/models/MovementSpec.scala
+++ b/test/models/MovementSpec.scala
@@ -18,9 +18,11 @@ package models
 
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
 
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class MovementSpec extends AnyFreeSpec with Matchers {
 

--- a/test/models/OfficeSpec.scala
+++ b/test/models/OfficeSpec.scala
@@ -16,7 +16,8 @@
 
 package models
 
-import models.RoutingOption.{Gb, Xi}
+import models.RoutingOption.Gb
+import models.RoutingOption.Xi
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 

--- a/test/services/RouteCheckerSpec.scala
+++ b/test/services/RouteCheckerSpec.scala
@@ -16,8 +16,10 @@
 
 package services
 
-import models.ChannelType.{Api, Web}
-import models.RoutingOption.{Gb, Xi}
+import models.ChannelType.Api
+import models.ChannelType.Web
+import models.RoutingOption.Gb
+import models.RoutingOption.Xi
 import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -25,56 +27,48 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.mockito.Mockito.when
 
-class RouteCheckerSpec
-    extends AnyFreeSpec
-    with MockitoSugar
-    with Matchers
-    with ScalaCheckDrivenPropertyChecks {
+class RouteCheckerSpec extends AnyFreeSpec with MockitoSugar with Matchers with ScalaCheckDrivenPropertyChecks {
 
   val routingOptionGen = Gen.oneOf[Boolean](true, false)
 
   "canForward" - {
     "when input route is Xi and channel is web, must return the RoutingOption for webNi in the appConfig" in {
-      forAll(routingOptionGen) { opt =>
-        {
+      forAll(routingOptionGen) {
+        opt =>
           val mockConfig = mock[RoutingConfig]
           when(mockConfig.webXi).thenReturn(opt)
 
           new RouteChecker(mockConfig).canForward(Xi, Web) mustBe opt
-        }
       }
     }
 
     "when input route is Xi and channel is api, must return the RoutingOption for apiXi in the appConfig" in {
-      forAll(routingOptionGen) { opt =>
-        {
+      forAll(routingOptionGen) {
+        opt =>
           val mockConfig = mock[RoutingConfig]
           when(mockConfig.apiXi).thenReturn(opt)
 
           new RouteChecker(mockConfig).canForward(Xi, Api) mustBe opt
-        }
       }
     }
 
     "when input route is Gb and channel is web, must return the RoutingOption for webGb in the appConfig" in {
-      forAll(routingOptionGen) { opt =>
-        {
+      forAll(routingOptionGen) {
+        opt =>
           val mockConfig = mock[RoutingConfig]
           when(mockConfig.webGb).thenReturn(opt)
 
           new RouteChecker(mockConfig).canForward(Gb, Web) mustBe opt
-        }
       }
     }
 
     "when input route is Gb and channel is api, must return the RoutingOption for apiGb in the appConfig" in {
-      forAll(routingOptionGen) { opt =>
-        {
+      forAll(routingOptionGen) {
+        opt =>
           val mockConfig = mock[RoutingConfig]
           when(mockConfig.apiGb).thenReturn(opt)
 
           new RouteChecker(mockConfig).canForward(Gb, Api) mustBe opt
-        }
       }
     }
   }

--- a/test/services/RoutingServiceSpec.scala
+++ b/test/services/RoutingServiceSpec.scala
@@ -19,21 +19,31 @@ package services
 import config.AppConfig
 import connectors.MessageConnector
 import models.ChannelType.Api
-import models.MessageType.{arrivalValues, departureValues}
+import models.MessageType.arrivalValues
+import models.MessageType.departureValues
 import models.ParseError._
-import models.RoutingOption.{Gb, Xi}
-import models.{ChannelType, FailureMessage, MessageType, RoutingOption}
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.{never, verify, when}
+import models.RoutingOption.Gb
+import models.RoutingOption.Xi
+import models.ChannelType
+import models.FailureMessage
+import models.MessageType
+import models.RoutingOption
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
 import org.scalacheck.Gen
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 import scala.xml.Elem
@@ -58,14 +68,23 @@ class RoutingServiceSpec
 
   val channelGen = Gen.oneOf(ChannelType.values)
   val routeGen   = Gen.oneOf(RoutingOption.values)
+
   val notNCTSMessageTypeGen = Gen.oneOf(
-    MessageType.values.filterNot(msg => (arrivalValues ++ departureValues) contains msg)
+    MessageType.values.filterNot(
+      msg => (arrivalValues ++ departureValues) contains msg
+    )
   )
+
   val nctsMessageTypeArrGen = Gen.oneOf(
-    MessageType.values.filter(msg => arrivalValues contains msg)
+    MessageType.values.filter(
+      msg => arrivalValues contains msg
+    )
   )
+
   val nctsMessageTypeDepGen = Gen.oneOf(
-    MessageType.values.filter(msg => departureValues contains msg)
+    MessageType.values.filter(
+      msg => departureValues contains msg
+    )
   )
 
   "submitMessage" - {
@@ -119,16 +138,17 @@ class RoutingServiceSpec
         </CC015B>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc).post(any(), eqTo(Xi), eqTo(hc))
+          verify(mc).post(any(), eqTo(Xi), eqTo(hc))
       }
     }
 
@@ -141,16 +161,17 @@ class RoutingServiceSpec
         </CC015B>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
 
@@ -163,17 +184,18 @@ class RoutingServiceSpec
         </CC015B>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc).post(any(), eqTo(Gb), eqTo(hc))
-        verify(mc).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Gb), eqTo(hc))
+          verify(mc).postNCTSMonitoring(any(), any(), any(), any())
       }
     }
 
@@ -186,22 +208,23 @@ class RoutingServiceSpec
         </CC015B>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
 
     "never posts a movement to NCTS monitoring if message type is not a Departure or Arrival message type" in {
 
-      def nonDepartureXml(messageCode: String): Elem = {
+      def nonDepartureXml(messageCode: String): Elem =
         scala.xml.XML.loadString(s"""
            |<TransitWrapper>
            |   <$messageCode>
@@ -210,18 +233,18 @@ class RoutingServiceSpec
            |      </GUAREF2>
            |   </$messageCode>
            |</TransitWrapper>""".stripMargin)
-      }
 
-      forAll(notNCTSMessageTypeGen, channelGen) { (messageType, channelType) =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(notNCTSMessageTypeGen, channelGen) {
+        (messageType, channelType) =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(any(), any())).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(any(), any())).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(nonDepartureXml(messageType.rootNode), channelType, hc)
-        verify(mc).post(any(), any(), any())
-        verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
+          service(fsrc, mc).submitMessage(nonDepartureXml(messageType.rootNode), channelType, hc)
+          verify(mc).post(any(), any(), any())
+          verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
       }
     }
 
@@ -235,27 +258,28 @@ class RoutingServiceSpec
         </CC015B>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
 
-        val mockAppConfig: AppConfig = mock[AppConfig]
+          val mockAppConfig: AppConfig = mock[AppConfig]
 
-        when(mockAppConfig.nctsMonitoringEnabled).thenReturn(false)
+          when(mockAppConfig.nctsMonitoringEnabled).thenReturn(false)
 
-        service(fsrc, mc, mockAppConfig).submitMessage(input, channel, hc)
+          service(fsrc, mc, mockAppConfig).submitMessage(input, channel, hc)
 
-        verify(mc).post(any(), eqTo(Gb), eqTo(hc))
-        verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Gb), eqTo(hc))
+          verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
       }
     }
 
     "posts arrivals to NCTS monitoring if ncts-monitoring feature is enabled" in {
 
-      def messageXML(rootNode: String): Elem = {
+      def messageXML(rootNode: String): Elem =
         scala.xml.XML.loadString(s"""
              |<TransitWrapper>
              |   <$rootNode>
@@ -264,27 +288,27 @@ class RoutingServiceSpec
              |      </CUSOFFPREOFFRES>
              |   </$rootNode>
              |</TransitWrapper>""".stripMargin)
-      }
 
-      forAll(nctsMessageTypeArrGen, channelGen) { (msgType, channel) =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
-        when(mc.postNCTSMonitoring(any(), any(), any(), any()))
-          .thenReturn(Future.successful(200))
+      forAll(nctsMessageTypeArrGen, channelGen) {
+        (msgType, channel) =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+          when(mc.postNCTSMonitoring(any(), any(), any(), any()))
+            .thenReturn(Future.successful(200))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(any(), any())).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(any(), any())).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(messageXML(msgType.rootNode), channel, hc)
+          service(fsrc, mc).submitMessage(messageXML(msgType.rootNode), channel, hc)
 
-        verify(mc).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), any(), any())
+          verify(mc).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), any(), any())
       }
     }
 
     "posts departures to NCTS monitoring if ncts-monitoring feature is enabled" in {
 
-      def messageXML(rootNode: String): Elem = {
+      def messageXML(rootNode: String): Elem =
         scala.xml.XML.loadString(s"""
              |<TransitWrapper>
              |   <$rootNode>
@@ -293,21 +317,21 @@ class RoutingServiceSpec
              |      </CUSOFFDEPEPT>
              |   </$rootNode>
              |</TransitWrapper>""".stripMargin)
-      }
 
-      forAll(nctsMessageTypeDepGen, channelGen) { (msgType, channel) =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
-        when(mc.postNCTSMonitoring(any(), any(), any(), any()))
-          .thenReturn(Future.successful(200))
+      forAll(nctsMessageTypeDepGen, channelGen) {
+        (msgType, channel) =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+          when(mc.postNCTSMonitoring(any(), any(), any(), any()))
+            .thenReturn(Future.successful(200))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(any(), any())).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(any(), any())).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(messageXML(msgType.rootNode), channel, hc)
+          service(fsrc, mc).submitMessage(messageXML(msgType.rootNode), channel, hc)
 
-        verify(mc).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), any(), any())
+          verify(mc).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), any(), any())
       }
     }
 
@@ -320,17 +344,18 @@ class RoutingServiceSpec
         </CC007A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), eqTo(Xi), eqTo(hc))
+          verify(mc).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Xi), eqTo(hc))
       }
     }
 
@@ -343,16 +368,17 @@ class RoutingServiceSpec
         </CC007A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
 
@@ -365,17 +391,18 @@ class RoutingServiceSpec
         </CC007A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), eqTo(Gb), eqTo(hc))
+          verify(mc).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Gb), eqTo(hc))
       }
     }
 
@@ -388,16 +415,17 @@ class RoutingServiceSpec
         </CC007A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
 
@@ -410,17 +438,18 @@ class RoutingServiceSpec
         </CD034A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), eqTo(Xi), eqTo(hc))
+          verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Xi), eqTo(hc))
       }
     }
 
@@ -433,16 +462,17 @@ class RoutingServiceSpec
         </CD034A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Xi), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
 
@@ -455,17 +485,18 @@ class RoutingServiceSpec
         </CD034A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(true)
 
-        service(fsrc, mc).submitMessage(input, channel, hc)
+          service(fsrc, mc).submitMessage(input, channel, hc)
 
-        verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
-        verify(mc).post(any(), eqTo(Gb), eqTo(hc))
+          verify(mc, never()).postNCTSMonitoring(any(), any(), any(), any())
+          verify(mc).post(any(), eqTo(Gb), eqTo(hc))
       }
     }
 
@@ -478,16 +509,17 @@ class RoutingServiceSpec
         </CD034A>
       </TransitWrapper>
 
-      forAll(channelGen) { channel =>
-        val mc = mock[MessageConnector]
-        when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
+      forAll(channelGen) {
+        channel =>
+          val mc = mock[MessageConnector]
+          when(mc.post(any(), any(), any())).thenReturn(Future.successful(HttpResponse(200, "")))
 
-        val fsrc = mock[RouteChecker]
-        when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
+          val fsrc = mock[RouteChecker]
+          when(fsrc.canForward(eqTo(Gb), eqTo(channel))).thenReturn(false)
 
-        val result = service(fsrc, mc).submitMessage(input, channel, hc)
+          val result = service(fsrc, mc).submitMessage(input, channel, hc)
 
-        result mustBe a[Left[FailureMessage, _]]
+          result mustBe a[Left[FailureMessage, _]]
       }
     }
   }


### PR DESCRIPTION
I need to write more tests for this if we're gonna go down this route, but the basic premise is to time out the HTTP call to EIS after 5 seconds (configurable) if a message is less than 500,000 bytes (configurable), else time out after 29 seconds (our current situation, configurable).

* Update sbt to 1.6.2
* Update hmrc-bootstrap to 7.8.0 for access to HttpClientV2 for withRequestTimeout
* scalafmt updated some formatting